### PR TITLE
fix: resolve all lint errors and warnings across packages

### DIFF
--- a/packages/core/src/components/SideBar.tsx
+++ b/packages/core/src/components/SideBar.tsx
@@ -4,7 +4,7 @@
  * Uses inline styles for framework-agnostic rendering.
  */
 import * as React from 'react';
-import type { IColumnDefinition, IDateFilterValue, SideBarPanelId, IFilters, FilterValue } from '../types';
+import type { IColumnDefinition, SideBarPanelId, IFilters, FilterValue } from '../types';
 
 /** Describes a filterable column for the sidebar filters panel. */
 export interface SideBarFilterColumn {

--- a/packages/core/src/hooks/useCellSelection.ts
+++ b/packages/core/src/hooks/useCellSelection.ts
@@ -110,7 +110,7 @@ export function useCellSelection(params: UseCellSelectionParams): UseCellSelecti
         isDraggingRef.current = true;
       }
     },
-    [colOffset, setActiveCell]
+    [colOffset, setActiveCell, setSelectionRange]
   );
 
   const handleSelectAllCells = useCallback(() => {
@@ -122,7 +122,7 @@ export function useCellSelection(params: UseCellSelectionParams): UseCellSelecti
       endCol: visibleColCount - 1,
     });
     setActiveCell({ rowIndex: 0, columnIndex: colOffset });
-  }, [rowCount, visibleColCount, colOffset, setActiveCell]);
+  }, [rowCount, visibleColCount, colOffset, setActiveCell, setSelectionRange]);
 
   /** Last known mouse position during drag — used by mouseUp to flush pending RAF work. */
   const lastMousePosRef = useRef<{ cx: number; cy: number } | null>(null);

--- a/packages/core/src/hooks/useDataGridState.ts
+++ b/packages/core/src/hooks/useDataGridState.ts
@@ -5,7 +5,6 @@ import { parseValue } from '../utils/valueParsers';
 import { computeAggregations } from '../utils/aggregationUtils';
 import type { HeaderFilterConfigInput, CellRenderDescriptorInput } from '../utils';
 import type { RowId, IOGridDataGridProps, IStatusBarProps, IColumnDef } from '../types';
-import type { ICellValueChangedEvent } from '../types';
 import { useRowSelection } from './useRowSelection';
 import { useCellEditing } from './useCellEditing';
 import { useActiveCell } from './useActiveCell';
@@ -17,7 +16,6 @@ import { useFillHandle } from './useFillHandle';
 import { useUndoRedo } from './useUndoRedo';
 import { useLatestRef } from './useLatestRef';
 import { useTableLayout } from './useTableLayout';
-import { CHECKBOX_COLUMN_WIDTH, DEFAULT_MIN_COLUMN_WIDTH, CELL_PADDING } from '../constants';
 
 // Stable no-op handlers used when cellSelection is disabled (module-scope = no re-renders)
 const NOOP = () => {};
@@ -325,7 +323,6 @@ export function useDataGridState<T>(
     desiredTableWidth,
     columnSizingOverrides,
     setColumnSizingOverrides,
-    onColumnResized: onColumnResizedFromLayout,
   } = useTableLayout({
     wrapperRef,
     visibleCols,

--- a/packages/core/src/hooks/useOGrid.ts
+++ b/packages/core/src/hooks/useOGrid.ts
@@ -8,12 +8,11 @@ import {
   useImperativeHandle,
 } from 'react';
 import {
-  getFilterField,
   mergeFilter,
   deriveFilterOptionsFromData,
   getMultiSelectFilterFields,
 } from '../utils/ogridHelpers';
-import { getCellValue, flattenColumns, processClientSideData } from '../utils';
+import { flattenColumns, processClientSideData } from '../utils';
 import { useFilterOptions } from './useFilterOptions';
 import { useSideBarState } from './useSideBarState';
 import type { SideBarProps } from '../components/SideBar';
@@ -356,7 +355,6 @@ export function useOGrid<T>(
       .finally(() => {
         if (id === fetchIdRef.current) setLoading(false);
       });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isServerSide,
     dataSource,

--- a/packages/core/src/hooks/usePeopleFilterState.ts
+++ b/packages/core/src/hooks/usePeopleFilterState.ts
@@ -31,7 +31,7 @@ export interface UsePeopleFilterStateResult {
 export function usePeopleFilterState(
   params: UsePeopleFilterStateParams
 ): UsePeopleFilterStateResult {
-  const { selectedUser, onUserChange, peopleSearch, isFilterOpen, filterType } = params;
+  const { onUserChange, peopleSearch, isFilterOpen, filterType } = params;
 
   const peopleInputRef = useRef<HTMLInputElement | null>(null);
   const peopleSearchTimeoutRef = useRef<number | undefined>(undefined);

--- a/packages/core/src/hooks/useRowSelection.ts
+++ b/packages/core/src/hooks/useRowSelection.ts
@@ -94,7 +94,7 @@ export function useRowSelection<T>(params: UseRowSelectionParams<T>): UseRowSele
       lastClickedRowRef.current = rowIndex;
       updateSelection(next);
     },
-    [rowSelection, getRowId, updateSelection]
+    [rowSelection, getRowId, updateSelection, itemsRef, selectedRowIdsRef]
   );
 
   const handleSelectAll = useCallback(

--- a/packages/core/src/utils/clientSideData.ts
+++ b/packages/core/src/utils/clientSideData.ts
@@ -66,7 +66,7 @@ export function processClientSideData<T>(
     }
   }
 
-  let rows = predicates.length > 0
+  const rows = predicates.length > 0
     ? data.filter((row) => {
         for (let i = 0; i < predicates.length; i++) {
           if (!predicates[i](row)) return false;

--- a/packages/fluent/src/DataGridTable/DataGridTable.tsx
+++ b/packages/fluent/src/DataGridTable/DataGridTable.tsx
@@ -166,10 +166,9 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
   const allowOverflowX = !suppressHorizontalScroll && containerWidth > 0 && (minTableWidth > containerWidth || desiredTableWidth > containerWidth);
 
   // Pre-compute column class maps (avoids per-cell .filter(Boolean).join(' '))
-  const { cellClassMap, headerClassMap, colIndexMap } = useMemo(() => {
+  const { cellClassMap, headerClassMap } = useMemo(() => {
     const cm: Record<string, string> = {};
     const hm: Record<string, string> = {};
-    const im = new Map<string, number>();
 
     for (let i = 0; i < visibleCols.length; i++) {
       const col = visibleCols[i];
@@ -183,13 +182,12 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
       if (isPinnedRight) { parts.push(styles.pinnedCell); parts.push(styles.pinnedRight); }
       cm[col.columnId] = parts.join(' ');
       hm[col.columnId] = parts.join(' ');
-      im.set(col.columnId, i);
     }
 
     cm['__selection__'] = styles.selectionCellWrapper;
     hm['__selection__'] = styles.selectionHeaderCellWrapper;
 
-    return { cellClassMap: cm, headerClassMap: hm, colIndexMap: im };
+    return { cellClassMap: cm, headerClassMap: hm };
   }, [visibleCols, freezeCols]);
 
   // Refs for volatile state (read inside fluentColumns render closures without adding to deps)
@@ -349,7 +347,7 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
     if (rowSelection !== 'single') return;
     const ids = selectedRowIdsRef.current;
     updateSelection(ids.has(rowId) ? new Set() : new Set([rowId]));
-  }, [rowSelection, updateSelection]);
+  }, [rowSelection, updateSelection, selectedRowIdsRef]);
 
   // Stable getRowId wrapper for Fluent DataGrid
   const fluentGetRowId = useCallback((item: T) => String(getRowId(item)), [getRowId]);

--- a/packages/material/src/DataGridTable/DataGridTable.tsx
+++ b/packages/material/src/DataGridTable/DataGridTable.tsx
@@ -330,7 +330,7 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
     if (!rowId) return;
     const ids = selectedRowIdsRef.current;
     updateSelection(ids.has(rowId) ? new Set() : new Set([rowId]));
-  }, [rowSelection, updateSelection]);
+  }, [rowSelection, updateSelection, selectedRowIdsRef]);
 
   // Wrapper sx (depends on dynamic values — memoize to avoid recreation)
   const wrapperSx = useMemo(() => ({
@@ -410,7 +410,7 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
         </CellErrorBoundary>
       );
     },
-    [editCallbacks, interactionHandlers, handleFillHandleMouseDown, setPopoverAnchorEl, cancelPopoverEdit, getRowId, onCellError]
+    [editCallbacks, interactionHandlers, handleFillHandleMouseDown, setPopoverAnchorEl, cancelPopoverEdit, getRowId, onCellError, cellDescriptorInputRef, pendingEditorValueRef, popoverAnchorElRef]
   );
 
   return (

--- a/packages/radix/src/DataGridTable/DataGridTable.tsx
+++ b/packages/radix/src/DataGridTable/DataGridTable.tsx
@@ -214,7 +214,7 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
     if (!rowId) return;
     const ids = selectedRowIdsRef.current;
     updateSelection(ids.has(rowId) ? new Set() : new Set([rowId]));
-  }, [rowSelection, updateSelection]);
+  }, [rowSelection, updateSelection, selectedRowIdsRef]);
 
   // Stable header select-all handler
   const handleSelectAllChecked = useCallback((c: boolean | 'indeterminate') => handleSelectAll(!!c), [handleSelectAll]);
@@ -278,7 +278,7 @@ function DataGridTableInner<T>(props: IOGridDataGridProps<T>): React.ReactElemen
         </CellErrorBoundary>
       );
     },
-    [editCallbacks, interactionHandlers, handleFillHandleMouseDown, setPopoverAnchorEl, cancelPopoverEdit, getRowId, onCellError]
+    [editCallbacks, interactionHandlers, handleFillHandleMouseDown, setPopoverAnchorEl, cancelPopoverEdit, getRowId, onCellError, cellDescriptorInputRef, pendingEditorValueRef, popoverAnchorElRef]
   );
 
   return (

--- a/packages/radix/src/DataGridTable/InlineCellEditor.tsx
+++ b/packages/radix/src/DataGridTable/InlineCellEditor.tsx
@@ -29,7 +29,6 @@ export function InlineCellEditor<T>(props: InlineCellEditorProps<T>): React.Reac
         </Checkbox.Root>
       )}
       renderSelect={(value, values, onCommit, onCancel) => {
-        const { column } = props;
         return (
           <div style={selectWrapperStyle}>
             <select


### PR DESCRIPTION
- Fix prefer-const error in clientSideData.ts (let → const)
- Remove unused imports: IDateFilterValue, ICellValueChangedEvent, getFilterField,
  getCellValue, CHECKBOX_COLUMN_WIDTH, DEFAULT_MIN_COLUMN_WIDTH, CELL_PADDING
- Remove unused variables: onColumnResizedFromLayout, selectedUser, colIndexMap, column
- Remove stale eslint-disable directive in useOGrid.ts
- Add missing React hook dependencies: setSelectionRange, itemsRef, selectedRowIdsRef,
  cellDescriptorInputRef, pendingEditorValueRef, popoverAnchorElRef

https://claude.ai/code/session_012Z2aQVgNf65ivfwMR8aGoX